### PR TITLE
FIX: custom domain name was lost when deploying new versions of pages

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+aicloud-docs.claaudia.aau.dk


### PR DESCRIPTION
This should problems with the custom domain name aicloud-docs.claaudia.aau.dk being lost every time a new version of the pages was deployed.
See:
- https://github.com/mkdocs/mkdocs/issues/1257
- https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
- https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors
- https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains