### PR TITLE
Update to reflect that the pilot platform is gone

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -16,19 +16,13 @@ usage](#fair-usage)
 
 <!--**It is intended that all analysis on AI Cloud II are run via  containers which you start and manage by yourselves. It is possible to build singularity images from the NVIDIA's stock docker images [NVIDIA GPU Cloud](https://ngc.nvidia.com/) - check also this [Support Matrix](https://docs.nvidia.com/deeplearning/dgx/support-matrix/index.html "support matrix"). If you need something of your own taste, all software tools and their dependencies are supposed to be installed inside your containers. Furthermore, if you want to use the software stack again and again, it is a good idea to create a singularity image for that.**-->
 
-The AI Cloud pilot platform consists of the following compute nodes:
-
-| Name                        | Nodes in total |GPUs per node   | CPU cores per node | CPU HW threads | RAM per node | RAM per GPU  | Disk         | NVLINK / NVSWITCH | Primary usage                         |
-| ---                         | ---            | ---            | ---                | ---            | ---          | ---          | ---          | ---               | ---                                   |
-| nv-ai-03.srv.aau.dk         | 1              | 16 (V100)      | 48 (Intel Xeon)    | 96             | 1470 GB      | 32 GB        | 30TB /raid   | Yes               | Large / batch / multi-GPU jobs        |
-
-The (new) AI Cloud consists of the following compute nodes:
+The AI Cloud consists of the following compute nodes:
 
 | Name                        | Nodes in total |GPUs per node   | CPU cores per node | CPU HW threads | RAM per node | RAM per GPU  | Disk         | NVLINK / NVSWITCH | Primary usage                         |
 | ---                         | ---            | ---            | ---                | ---            | ---          | ---          | ---          | ---               | ---                                   |
 | a256-t4-[01-03].srv.aau.dk  | 3              | 6 (NVIDIA T4)  | 32 (AMD EPYC)      | 64             | 256 GB       | 16 GB        | None locally | No                | Interactive / smaller single-GPU jobs |
 | i256-a10-[06-10].srv.aau.dk | 5              | 4 (NVIDIA A10) | 32 (Intel Xeon)    | 64             | 256 GB       | 24 GB        | None locally | No                | Interactive / smaller single-GPU jobs |
-| nv-ai-01.srv.aau.dk         | 1              | 16 (V100)      | 48 (Intel Xeon)    | 96             | 1470 GB      | 32 GB        | 30TB /raid   | Yes               | Large / batch / multi-GPU jobs        |
+| nv-ai-[01-02].srv.aau.dk    | 2              | 16 (V100)      | 48 (Intel Xeon)    | 96             | 1470 GB      | 32 GB        | 30TB /raid   | Yes               | Large / batch / multi-GPU jobs        |
 | nv-ai-04.srv.aau.dk         | 1              | 8 (A100)       | 128 (AMD EPYC)     | 256            | 980 GB       | 40 GB        | 14TB /raid   | Yes               | Large / batch / multi-GPU jobs        |
 
 ## Getting started
@@ -81,31 +75,16 @@ the following command on the command line of your local computer:
 
 ???+ example
 
-    === "AI Cloud"
-
-        ```console
-        ssh -l <aau email> ai-fe02.srv.aau.dk
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        ssh -l <aau email> ai-pilot.srv.aau.dk
-        ```
+    ```console
+    ssh -l <aau email> ai-fe02.srv.aau.dk
+    ```
 
     Replace `<aau email>` with your AAU email address, e.g.
 
-    === "AI Cloud"
 
-        ```console
-        ssh -l tari@its.aau.dk ai-fe02.srv.aau.dk
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        ssh -l tari@its.aau.dk ai-pilot.srv.aau.dk
-        ```
+   ```console
+   ssh -l tari@its.aau.dk ai-fe02.srv.aau.dk
+   ```
 
 If you wish to access while **not** being connected to the AAU
 network, you have two options: [Use
@@ -118,21 +97,11 @@ gateway](https://www.en.its.aau.dk/instructions/Username+and+password/SSH/).
     through your personal SSH configuration (in Linux/OS X this is often
     located in: `$HOME/.ssh/config`).
 
-    === "AI Cloud"
-
-        ```console
-        Host ai-fe02.srv.aau.dk
-             User <aau email>
-             ProxyJump %r@sshgw.aau.dk
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        Host ai-pilot.srv.aau.dk
-             User <aau email>
-             ProxyJump %r@sshgw.aau.dk
-        ```
+    ```console
+    Host ai-fe02.srv.aau.dk
+         User <aau email>
+         ProxyJump %r@sshgw.aau.dk
+    ```
 
     Add the above configuration to your personal ssh config file (often
     located in: `$HOME/.ssh/config` on Linux or OS X systems). Now you
@@ -146,52 +115,29 @@ You can transfer files to/from AI Cloud using the command line utility
 
 ???+ example
 
-    === "AI Cloud"
-
-        ```console
-        scp some-file <aau email>@ai-fe02.srv.aau.dk:~
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        scp some-file <aau email>@ai-pilot.srv.aau.dk:~
-        ```
+    ```console
+	scp some-file <aau email>@ai-fe02.srv.aau.dk:~
+	```
 
     where '~' means your user directory on AI Cloud. You can append
     directories below that to your destination:
 
 ???+ example
 
-    === "AI Cloud"
-
-        ```console
-        scp some-file <aau email>@ai-fe02.srv.aau.dk:~/some-dir/some-sub-dir/
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        scp some-file <aau email>@ai-pilot.srv.aau.dk:~/some-dir/some-sub-dir/
-        ```
+    ```console
+	scp some-file <aau email>@ai-fe02.srv.aau.dk:~/some-dir/some-sub-dir/
+	```
 
 You can also copy in the opposite direction, e.g. from the AI Cloud
 pilot platform to your local computer with:
 
 ???+ example
 
-    === "AI Cloud"
+    ```console
+	scp <aau email>@ai-fe02.srv.aau.dk:~/some-folder/some-subfolder/some-file .
+	```
 
-        ```console
-        scp <aau email>@ai-fe02.srv.aau.dk:~/some-folder/some-subfolder/some-file .
-        ```
-
-    === "AI Cloud pilot platform"
-
-        ```console
-        scp <aau email>@ai-pilot.srv.aau.dk:~/some-folder/some-subfolder/some-file .
-        ```
-	where '.' means the current directory you are located in on your local
+    where '.' means the current directory you are located in on your local
 	computer.
 
 In general, file transfer tools that can use SSH as protocol should

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,9 +9,9 @@ how to best use the described platforms.
 
 ## AI Cloud
 
-The (new) AI Cloud is the second generation of the AI Cloud which has
+The AI Cloud is the second generation of CLAAUDIA's AI Cloud service which has
 gradually been put into service since 2021.  
-The AI Cloud consists of a front-end node and a number of compute
+The AI Cloud consists of a front-end node (ai-fe02.srv.aau.dk) and a number of compute
 nodes. The AI Cloud is a heterogeneous platform with several different
 types of hardware available in the compute nodes.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,22 +1,21 @@
 # AI Cloud structure
 
-The AI Cloud currently consists of two separate platforms: the [AI
-Cloud pilot platform](#ai-cloud-pilot-platform) and the "new" [AI
-Cloud](#ai-cloud-new) which will continue as the sole platform in the
-near future.
+The [AI Cloud](#ai-cloud-new) is a cluster consisting of a number of
+nodes (servers).
 
 You are always welcome to [contact the CLAAUDIA
 team](https://www.claaudia.aau.dk/support-advisory/) for guidance on
 how to best use the described platforms.
 
-## AI Cloud pilot platform
+## AI Cloud
 
-The AI Cloud pilot platform is the first generation of the AI Cloud
-and has been in service since 2019. The pilot platform consists of a
-front-end node (or log-in or gateway node if you will) and two compute
-nodes. Most existing users will know this as "the AI Cloud".
+The (new) AI Cloud is the second generation of the AI Cloud which has
+gradually been put into service since 2021.  
+The AI Cloud consists of a front-end node and a number of compute
+nodes. The AI Cloud is a heterogeneous platform with several different
+types of hardware available in the compute nodes.
 
-![AI Cloud pilot platform](assets/img/ai-cloud-pilot-overview.png)
+![AI Cloud platform](assets/img/ai-cloud-overview.png)
 
 The front-end node is used for logging into the platform, accessing
 your files, and starting jobs on the compute nodes. The front-end node
@@ -24,35 +23,8 @@ is a relatively small server which is *not* meant for performing heavy
 computations; only light-weight operations such as transferring files
 to and from AI Cloud and defining and launching job scripts.
 
-The details of defining and running jobs is described in the
+The details of defining and running jobs are described in the
 [introduction](introduction.md).
-
-The single remaining compute node nv-ai-03 is an [NVIDIA DGX-2
-server](https://www.nvidia.com/en-us/data-center/dgx-2/). The
-compute node is equipped with 2 &times; 24-core Intel Xeon CPUs, 1.5 TB of
-system RAM, and 16 [NVIDIA Tesla V100
-GPUs](https://www.nvidia.com/en-us/data-center/v100/) with 32 GB of
-RAM each, all connected via NVIDIA NVLink.  
-This is a very powerful server which you can use smaller or larger
-portions of for shorter or longer duration. Details on how can be
-found in the [introduction](introduction.md).
-
-???+ note
-
-    In the future, the AI Cloud pilot platform will be
-    decomissioned and its compute node included in the (new) AI
-    Cloud described below.
-
-## AI Cloud (new)
-
-The (new) AI Cloud is the second generation of the AI Cloud which has
-gradually been put into service since 2021.  
-Like the the pilot platform, the AI Cloud consists of a front-end node
-and a number of compute nodes. In contrast to the AI Cloud pilot
-platform, the newer AI Cloud is a heterogeneous platform with several
-different types of hardware available in the compute nodes.
-
-![AI Cloud (new) platform](assets/img/ai-cloud-overview.png)
 
 The compute nodes of the AI Cloud currently include:
 
@@ -65,34 +37,48 @@ The compute nodes of the AI Cloud currently include:
   A10
   GPUs](https://www.nvidia.com/en-us/data-center/products/a10-gpu/)
   (24 GB of RAM each).
-- One [NVIDIA DGX-2
-server](https://www.nvidia.com/en-us/data-center/dgx-2/) server named
-nv-ai-01; identical to nv-ai-03 above.
+- Two [NVIDIA DGX-2
+  servers](https://www.nvidia.com/en-us/data-center/dgx-2/) named
+  nv-ai-01 and nv-ai-02; a third server named nv-ai-03 will be added
+  soon. These compute node are each equipped with 2 &times; 24-core
+  Intel Xeon CPUs, 1.5 TB of system RAM, and 16 [NVIDIA Tesla V100
+  GPUs](https://www.nvidia.com/en-us/data-center/v100/) with 32 GB of
+  RAM each, all connected via NVIDIA NVLink.  
+  These are very powerful servers which you can use smaller or larger
+  portions of for shorter or longer duration. Details on how can be
+  found in the [introduction](introduction.md).
 - One [NVIDIA
   DGX-A100](https://www.nvidia.com/en-us/data-center/dgx-a100/) server
   named nv-ai-04. This compute node is equipped with AMD CPUs (2 &times; AMD
   Rome 7742 64-core), 2TB of system RAM, and 8 [NVIDIA A100
   GPUs](https://www.nvidia.com/en-us/data-center/a100/) (40GB of RAM
   each).
-- In the future, the newer AI Cloud will also contain the compute
-  node nv-ai-03 from the AI Cloud pilot platform.
   
 !!! important
 
     Special conditions apply for using the compute node nv-ai-04; see
     [introduction](introduction.md).
 
-This more diverse selection (compared to the pilot platform) of
+This diverse selection of
 different hardware in the AI Cloud allows for more suitable choice of
 specific hardware according to your task. For example, the DGX-2
-compute nodes of the AI Cloud pilot platform are better suited for the
+compute nodes are better suited for the
 comutationally intensive training of deep neural networks, while the
 compute nodes with T4 GPUs are better suited for inference tasks using
 an already trained model.
 
+## AI Cloud pilot platform
+
+The AI Cloud pilot platform was the first generation of the AI Cloud
+and was in service 2019-2022. This platform was available through the
+front-end node ai-pilot.srv.aau.dk (also known as
+nv-ai-fe01.srv.aau.dk), but *no longer exists*.  
+If you had data in the AI Cloud pilot platform, this is still
+available through the current front-end node instead.
+
 ## Operating system, file storage, and application framework
 
-The AI Cloud (and -pilot platform) is based on [Ubuntu
+The AI Cloud is based on [Ubuntu
 Linux](https://en.wikipedia.org/wiki/Ubuntu) as its operating
 system. In practice, working in the AI Cloud primarily takes place via
 a [command-line
@@ -145,17 +131,11 @@ See details on container images from NGC in the
 
 ### File storage
 
-Both the AI Cloud pilot platform and the newer AI Cloud store your
+The AI Cloud stores your
 files in your user directory. Your user directory is stored on a
-network file system that allows all of the nodes within each platform
+network file system that allows all of the nodes within the platform
 can access your files. This means that if you store or edit a file in
-your user directory on the front-end node, the compute nodes in the
-same platform can see the same file and contents thereof. The nodes
+your user directory on the front-end node, the compute nodes
+can see the same file and contents thereof. The nodes
 access the network file system in a shared manner, so there is nothing
 you need to do to synchronise the files between the nodes.
-
-The AI Cloud pilot platform and the newer AI Cloud use separate
-network file systems. This means that on the AI Cloud pilot platform,
-you cannot directly see the files in the newer AI Cloud and vice
-versa. You can, however, copy files between them manually; please see
-[Introduction; transferring files](introduction.md#transferring-files).


### PR DESCRIPTION
I updated the Overview and Introduction pages to reflect the fact that the pilot platform has been discontinued. The Overview page mentions what the pilot platform was and that it is now gone. The introduction page has had the pilot platform variant of all the examples removed.  
Both pages have had their tables of compute nodes updated. nv-ai-03 is still to be added to the tables when it is ready.