### PR TITLE
Requeueing

### DIFF
--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -141,33 +141,32 @@ resources in AI Cloud.
 
 ## Selecting a partition
 
+### The *prioritized* partition
+
+The default partition in AI Cloud is *prioritized*. If you submit a
+job without specifying a partition, e.g. `sbatch --gres=gpu:1
+job_script.sh`, your job automatically gets run in the *prioritized*
+partition. All users have access to the *prioritized* partition. As
+shown in the `sinfo` example above, this partition has a 6-day time
+limit and other jobs cannot cancel jobs in this partition.
+
 ### The *batch* partition
 
-The default partition in AI Cloud is *batch*. If you submit a job
-without specifying a partition, e.g. `sbatch --gres=gpu:1
-job_script.sh`, your job automatically gets run in the *batch*
-partition. As shown in the `sinfo` example above, the batch partition
+As shown in the `sinfo` example above, the batch partition
 has a time limit of 12 hours and furthermore, jobs can get cancelled
 (pre-empted) by other jobs running in other partitions. As a regular
 user, the batch partition is the only way you can get access to the
 special compute nodes mentioned in [Introduction -
 Overview](introduction.md#overview) which belong to particular
-research groups.
+research groups. Except for those compute nodes, the *batch* partition
+is not very interesting to use due to the pre-emption feature.
 
-### The *prioritized* partition
-
-All users also have access to the *prioritized* partition. As shown in
-the `sinfo` example above, this partition has a 6-day time limit and
-other jobs cannot cancel jobs in this partition. The 6-day time limit
-is a temporary feature that we may decrease in the future when
-everyone gets more used to re-queueing jobs.
-
-In order to use the *prioritized* partition, you must specify it for
+In order to use the *batch* partition, you must specify it for
 your jobs with the "--partition" or "-p" option:
 
 ???+ example
 
-        sbatch -p prioritized --gres=gpu:1 job_script.sh
+        sbatch -p batch --gres=gpu:1 job_script.sh
 
     Using the "-p" option to specify a partition for a batch job.
 

--- a/docs/slurm.md
+++ b/docs/slurm.md
@@ -297,10 +297,16 @@ functionality to your program:
 2. If the file exists; load it and continue work from there.
 3. If not; start the work from scratch.
 4. While working; save the necessary internal data and output data so
-   far to a checkpoint file.
+   far to a checkpoint file at regular time intervals.
 5. When the program completes without errors; save the final output
    data the way you would normally save your output data and delete
    the checkpoint file.
+
+For example, if your program stores a checkpoint every 15 minutes, you
+would only risk losing up to 15 minutes of work if the job gets
+stopped. All of the prior work is stored in your most recent
+checkpoint which your workload can automatically load and continue
+from.
 
 Some popular libraries often used in AI Cloud have built-in features
 you can use for checkpointing:


### PR DESCRIPTION
This PR updates the documentation to explain that the *prioritized* partition now only allows jobs to run up to 24 hours. It also explains how requeueing and checkpointing can be used to run workloads longer than 24 hours.